### PR TITLE
履歴画面にグラフを追加

### DIFF
--- a/app/src/main/java/jp/ta7sus4/healthcareai/diagnosis/DiagnosisHistoryScreen.kt
+++ b/app/src/main/java/jp/ta7sus4/healthcareai/diagnosis/DiagnosisHistoryScreen.kt
@@ -140,7 +140,7 @@ fun DiagnosisHistoryScreen(
                 Text("履歴", modifier = Modifier.padding(start = 10.dp, end = 10.dp, bottom = 10.dp))
             }
             LazyColumn {
-                items(viewModel.historyList) { history ->
+                items(viewModel.historyList.reversed()) { history ->
                     key(history.id) {
                         DiagnosisHistoryCard(viewModel = viewModel, history = history)
                     }

--- a/app/src/main/java/jp/ta7sus4/healthcareai/diagnosis/DiagnosisHistoryScreen.kt
+++ b/app/src/main/java/jp/ta7sus4/healthcareai/diagnosis/DiagnosisHistoryScreen.kt
@@ -1,11 +1,14 @@
 package jp.ta7sus4.healthcareai.diagnosis
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -22,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
@@ -36,6 +40,42 @@ import java.util.Locale
 object DateFormats {
     val historyFormat = SimpleDateFormat("yyyy/MM/dd HH:mm:ss", Locale.ROOT)
 }
+
+@Composable
+fun LineGraph(
+    data: List<Int>,
+    modifier: Modifier = Modifier,
+) {
+    Box (
+        modifier = modifier.padding(horizontal = 10.dp, vertical = 15.dp)
+    ) {
+        Text("${data.maxOrNull() ?: 0f}", fontSize = 10.sp, modifier = Modifier.align(Alignment.TopStart))
+        Text("${data.minOrNull() ?: 0f}", fontSize = 10.sp, modifier = Modifier.align(Alignment.BottomStart))
+        Canvas(modifier = Modifier
+            .fillMaxWidth()
+            .height(110.dp)
+            .padding(start = 30.dp, end = 10.dp, top = 5.dp, bottom = 5.dp)
+        ) {
+            val maxValue = data.maxOrNull() ?: 1
+            val minValue = data.minOrNull() ?: 0
+            val heightScale = size.height / (maxValue - minValue)
+            val widthStep = size.width / (data.size - 1)
+            for (i in 0 until data.size - 1) {
+                val x1 = i * widthStep
+                val y1 = size.height - ((data[i] - minValue) * heightScale)
+                val x2 = (i + 1) * widthStep
+                val y2 = size.height - ((data[i + 1] - minValue) * heightScale)
+                drawLine(
+                    start = Offset(x1, y1),
+                    end = Offset(x2, y2),
+                    color = Color.Gray,
+                    strokeWidth = 5f
+                )
+            }
+        }
+    }
+}
+
 
 @Composable
 fun DiagnosisHistoryScreen(
@@ -80,25 +120,25 @@ fun DiagnosisHistoryScreen(
         }
         if (viewModel.historyList.size == 0 ) {
             Spacer(modifier = Modifier.weight(1.1f))
-            Row (
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Outlined.Info,
-                    tint = Color.Gray,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .padding(top = 2.dp, end = 4.dp)
-                        .size(22.dp)
-                )
-                Text(
-                    text = stringResource(id = R.string.no_history),
-                    fontSize = 18.sp,
-                    color = Color.Gray,
-                )
-            }
+            HistoryInformation(textResource = R.string.no_history)
             Spacer(modifier = Modifier.weight(1f))
         } else {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("スコアの推移", modifier = Modifier.padding(horizontal = 10.dp))
+                if (viewModel.historyList.size >= 2) {
+                    Card(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+                    ) {
+                        LineGraph(data = viewModel.historyList.map { it.score })
+                    }
+                } else {
+                    HistoryInformation(textResource = R.string.history_not_enough, modifier = Modifier.padding(vertical = 50.dp))
+                }
+                Text("履歴", modifier = Modifier.padding(start = 10.dp, end = 10.dp, bottom = 10.dp))
+            }
             LazyColumn {
                 items(viewModel.historyList) { history ->
                     key(history.id) {
@@ -155,6 +195,31 @@ fun DiagnosisHistoryCard(
                     .padding(start = 4.dp)
             )
         }
+    }
+}
+
+@Composable
+fun HistoryInformation(
+    textResource: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row (
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Icon(
+            Icons.Outlined.Info,
+            tint = Color.Gray,
+            contentDescription = null,
+            modifier = Modifier
+                .padding(top = 2.dp, end = 4.dp)
+                .size(22.dp)
+        )
+        Text(
+            text = stringResource(id = textResource),
+            fontSize = 18.sp,
+            color = Color.Gray,
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,6 @@
     <string name="no">いいえ</string>
     <string name="history">履歴</string>
     <string name="no_history">履歴はありません</string>
+    <string name="history_not_enough">履歴が不足しています</string>
     <string name="delete_all">すべて消去</string>
-
 </resources>


### PR DESCRIPTION
## 説明
履歴画面にグラフを追加した
## 目的や背景
スコアを可視化して推移をわかりやすくすべきかも
## スクリーンショットや動画(UI変更時のみ)
<img src="https://github.com/ta7sus4/HealthcareAi/assets/85665552/46ca839d-36e4-4ba6-a154-04cef0d77175" width=400>
